### PR TITLE
Add Javadoc Comments for Office365 Data Store Classes

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/office365/Office365DataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/office365/Office365DataStore.java
@@ -34,10 +34,28 @@ import com.microsoft.graph.models.Group;
 import com.microsoft.graph.models.User;
 import com.microsoft.graph.options.QueryOption;
 
+/**
+ * This is an abstract base class for Office 365 data stores.
+ * It provides common functionality for accessing Office 365 services,
+ * such as user and group management, and thread pool creation.
+ */
 public abstract class Office365DataStore extends AbstractDataStore {
+
+    /**
+     * Default constructor.
+     */
+    public Office365DataStore() {
+        super();
+    }
 
     private static final Logger logger = LogManager.getLogger(Office365DataStore.class);
 
+    /**
+     * Retrieves all licensed users and processes them with the provided consumer.
+     *
+     * @param client The Office365Client to use for the request.
+     * @param consumer A consumer to process each licensed User object.
+     */
     protected void getLicensedUsers(final Office365Client client, final Consumer<User> consumer) {
         client.getUsers(Collections.emptyList(), u -> {
             if (isLicensedUser(client, u.id)) {
@@ -46,6 +64,12 @@ public abstract class Office365DataStore extends AbstractDataStore {
         });
     }
 
+    /**
+     * Creates a new fixed-size thread pool for executing tasks concurrently.
+     *
+     * @param nThreads The number of threads in the pool.
+     * @return A new ExecutorService with a fixed thread pool.
+     */
     protected ExecutorService newFixedThreadPool(final int nThreads) {
         if (logger.isDebugEnabled()) {
             logger.debug("Executor Thread Pool: {}", nThreads);
@@ -54,19 +78,44 @@ public abstract class Office365DataStore extends AbstractDataStore {
                 new ThreadPoolExecutor.CallerRunsPolicy());
     }
 
+    /**
+     * Checks if a user is licensed by their ID.
+     *
+     * @param client The Office365Client to use for the request.
+     * @param userId The ID of the user to check.
+     * @return true if the user is licensed, false otherwise.
+     */
     protected boolean isLicensedUser(final Office365Client client, final String userId) {
         final User user = client.getUser(userId, Collections.singletonList(new QueryOption("$select", "assignedLicenses")));
         return user.assignedLicenses.stream().anyMatch(license -> Objects.nonNull(license.skuId));
     }
 
+    /**
+     * Retrieves the roles for a user.
+     *
+     * @param user The user to retrieve roles for.
+     * @return A list of role strings for the user.
+     */
     protected List<String> getUserRoles(final User user) {
         return Collections.singletonList(ComponentUtil.getSystemHelper().getSearchRoleByUser(user.id));
     }
 
+    /**
+     * Retrieves all Office 365 groups and processes them with the provided consumer.
+     *
+     * @param client The Office365Client to use for the request.
+     * @param consumer A consumer to process each Group object.
+     */
     protected void getOffice365Groups(final Office365Client client, final Consumer<Group> consumer) {
         client.getGroups(Collections.singletonList(new QueryOption("$filter", "groupTypes/any(c:c eq 'Unified')")), consumer);
     }
 
+    /**
+     * Retrieves the roles for a group.
+     *
+     * @param group The group to retrieve roles for.
+     * @return A list of role strings for the group.
+     */
     protected List<String> getGroupRoles(final Group group) {
         return Collections.singletonList(ComponentUtil.getSystemHelper().getSearchRoleByGroup(group.id));
     }

--- a/src/main/java/org/codelibs/fess/ds/office365/OneDriveDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/office365/OneDriveDataStore.java
@@ -70,71 +70,139 @@ import com.microsoft.graph.requests.PermissionCollectionPage;
 
 import okhttp3.Request;
 
+/**
+ * This class is a data store for crawling and indexing files in Microsoft OneDrive.
+ * It supports crawling user drives, group drives, and shared document libraries.
+ * It also handles file metadata, permissions, and content extraction.
+ */
 public class OneDriveDataStore extends Office365DataStore {
+
+    /**
+     * Default constructor.
+     */
+    public OneDriveDataStore() {
+        super();
+    }
 
     private static final Logger logger = LogManager.getLogger(OneDriveDataStore.class);
 
-    protected static final long DEFAULT_MAX_SIZE = -1;
+    /** Default maximum size of a file to be crawled. */
+    protected static final long DEFAULT_MAX_SIZE = -1L;
 
+    /** Key for the current crawler type in the configuration map. */
     protected static final String CURRENT_CRAWLER = "current_crawler";
+    /** Crawler type for group drives. */
     protected static final String CRAWLER_TYPE_GROUP = "group";
+    /** Crawler type for user drives. */
     protected static final String CRAWLER_TYPE_USER = "user";
+    /** Crawler type for shared drives. */
     protected static final String CRAWLER_TYPE_SHARED = "shared";
+    /** Crawler type for a specific drive. */
     protected static final String CRAWLER_TYPE_DRIVE = "drive";
+    /** Key for drive information in the configuration map. */
     protected static final String DRIVE_INFO = "drive_info";
 
     // parameters
+    /** Parameter name for the maximum content length. */
     protected static final String MAX_CONTENT_LENGTH = "max_content_length";
+    /** Parameter name for ignoring folders. */
     protected static final String IGNORE_FOLDER = "ignore_folder";
+    /** Parameter name for ignoring errors. */
     protected static final String IGNORE_ERROR = "ignore_error";
+    /** Parameter name for supported MIME types. */
     protected static final String SUPPORTED_MIMETYPES = "supported_mimetypes";
+    /** Parameter name for the include pattern for URLs. */
     protected static final String INCLUDE_PATTERN = "include_pattern";
+    /** Parameter name for the exclude pattern for URLs. */
     protected static final String EXCLUDE_PATTERN = "exclude_pattern";
+    /** Parameter name for the URL filter. */
     protected static final String URL_FILTER = "url_filter";
+    /** Parameter name for the drive ID. */
     protected static final String DRIVE_ID = "drive_id";
+    /** Parameter name for default permissions. */
     protected static final String DEFAULT_PERMISSIONS = "default_permissions";
+    /** Parameter name for the number of threads. */
     protected static final String NUMBER_OF_THREADS = "number_of_threads";
+    /** Parameter name for enabling the shared documents drive crawler. */
     protected static final String SHARED_DOCUMENTS_DRIVE_CRAWLER = "shared_documents_drive_crawler";
+    /** Parameter name for enabling the user drive crawler. */
     protected static final String USER_DRIVE_CRAWLER = "user_drive_crawler";
+    /** Parameter name for enabling the group drive crawler. */
     protected static final String GROUP_DRIVE_CRAWLER = "group_drive_crawler";
 
     // scripts
+    /** Key for the file object in the script map. */
     protected static final String FILE = "file";
+    /** Key for the file name in the script map. */
     protected static final String FILE_NAME = "name";
+    /** Key for the file description in the script map. */
     protected static final String FILE_DESCRIPTION = "description";
+    /** Key for the file contents in the script map. */
     protected static final String FILE_CONTENTS = "contents";
+    /** Key for the file MIME type in the script map. */
     protected static final String FILE_MIMETYPE = "mimetype";
+    /** Key for the file type in the script map. */
     protected static final String FILE_FILETYPE = "filetype";
+    /** Key for the file creation date in the script map. */
     protected static final String FILE_CREATED = "created";
+    /** Key for the file last modified date in the script map. */
     protected static final String FILE_LAST_MODIFIED = "last_modified";
+    /** Key for the file size in the script map. */
     protected static final String FILE_SIZE = "size";
+    /** Key for the file web URL in the script map. */
     protected static final String FILE_WEB_URL = "web_url";
+    /** Key for the file URL in the script map. */
     protected static final String FILE_URL = "url";
+    /** Key for the file roles in the script map. */
     protected static final String FILE_ROLES = "roles";
+    /** Key for the file cTag in the script map. */
     protected static final String FILE_CTAG = "ctag";
+    /** Key for the file eTag in the script map. */
     protected static final String FILE_ETAG = "etag";
+    /** Key for the file ID in the script map. */
     protected static final String FILE_ID = "id";
+    /** Key for the file WebDAV URL in the script map. */
     protected static final String FILE_WEBDAV_URL = "webdav_url";
+    /** Key for the file location in the script map. */
     protected static final String FILE_LOCATION = "location";
+    /** Key for the application that created the file in the script map. */
     protected static final String FILE_CREATEDBY_APPLICATION = "createdby_application";
+    /** Key for the device that created the file in the script map. */
     protected static final String FILE_CREATEDBY_DEVICE = "createdby_device";
+    /** Key for the user who created the file in the script map. */
     protected static final String FILE_CREATEDBY_USER = "createdby_user";
+    /** Key for the deleted status of the file in the script map. */
     protected static final String FILE_DELETED = "deleted";
+    /** Key for the file hashes in the script map. */
     protected static final String FILE_HASHES = "hashes";
+    /** Key for the application that last modified the file in the script map. */
     protected static final String FILE_LAST_MODIFIEDBY_APPLICATION = "last_modifiedby_application";
+    /** Key for the device that last modified the file in the script map. */
     protected static final String FILE_LAST_MODIFIEDBY_DEVICE = "last_modifiedby_device";
+    /** Key for the user who last modified the file in the script map. */
     protected static final String FILE_LAST_MODIFIEDBY_USER = "last_modifiedby_user";
+    /** Key for the file image in the script map. */
     protected static final String FILE_IMAGE = "image";
+    /** Key for the file parent in the script map. */
     protected static final String FILE_PARENT = "parent";
+    /** Key for the file parent ID in the script map. */
     protected static final String FILE_PARENT_ID = "parent_id";
+    /** Key for the file parent name in the script map. */
     protected static final String FILE_PARENT_NAME = "parent_name";
+    /** Key for the file parent path in the script map. */
     protected static final String FILE_PARENT_PATH = "parent_path";
+    /** Key for the file photo in the script map. */
     protected static final String FILE_PHOTO = "photo";
+    /** Key for the file publication in the script map. */
     protected static final String FILE_PUBLICATION = "publication";
+    /** Key for the file search result in the script map. */
     protected static final String FILE_SEARCH_RESULT = "search_result";
+    /** Key for the file special folder in the script map. */
     protected static final String FILE_SPECIAL_FOLDER = "special_folder";
+    /** Key for the file video in the script map. */
     protected static final String FILE_VIDEO = "video";
 
+    /** The name of the extractor to use for file content. */
     protected String extractorName = "tikaExtractor";
 
     @Override
@@ -206,10 +274,22 @@ public class OneDriveDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Creates a new Office365Client.
+     *
+     * @param params The data store parameters.
+     * @return A new Office365Client.
+     */
     protected Office365Client createClient(final DataStoreParams params) {
         return new Office365Client(params);
     }
 
+    /**
+     * Gets the URL filter from the data store parameters.
+     *
+     * @param paramMap The data store parameters.
+     * @return The URL filter.
+     */
     protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
         final UrlFilter urlFilter = ComponentUtil.getComponent(UrlFilter.class);
         final String include = paramMap.getAsString(INCLUDE_PATTERN);
@@ -227,26 +307,62 @@ public class OneDriveDataStore extends Office365DataStore {
         return urlFilter;
     }
 
+    /**
+     * Checks if the shared documents drive crawler is enabled.
+     *
+     * @param paramMap The data store parameters.
+     * @return true if the shared documents drive crawler is enabled, false otherwise.
+     */
     protected boolean isSharedDocumentsDriveCrawler(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(SHARED_DOCUMENTS_DRIVE_CRAWLER, Constants.TRUE));
     }
 
+    /**
+     * Checks if the user drive crawler is enabled.
+     *
+     * @param paramMap The data store parameters.
+     * @return true if the user drive crawler is enabled, false otherwise.
+     */
     protected boolean isUserDriveCrawler(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(USER_DRIVE_CRAWLER, Constants.TRUE));
     }
 
+    /**
+     * Checks if the group drive crawler is enabled.
+     *
+     * @param paramMap The data store parameters.
+     * @return true if the group drive crawler is enabled, false otherwise.
+     */
     protected boolean isGroupDriveCrawler(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(GROUP_DRIVE_CRAWLER, Constants.TRUE));
     }
 
+    /**
+     * Checks if folders should be ignored.
+     *
+     * @param paramMap The data store parameters.
+     * @return true if folders should be ignored, false otherwise.
+     */
     protected boolean isIgnoreFolder(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(IGNORE_FOLDER, Constants.TRUE));
     }
 
+    /**
+     * Checks if errors should be ignored.
+     *
+     * @param paramMap The data store parameters.
+     * @return true if errors should be ignored, false otherwise.
+     */
     protected boolean isIgnoreError(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(IGNORE_ERROR, Constants.TRUE));
     }
 
+    /**
+     * Gets the maximum content length from the data store parameters.
+     *
+     * @param paramMap The data store parameters.
+     * @return The maximum content length.
+     */
     protected long getMaxSize(final DataStoreParams paramMap) {
         final String value = paramMap.getAsString(MAX_CONTENT_LENGTH);
         try {
@@ -256,11 +372,30 @@ public class OneDriveDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Gets the supported MIME types from the data store parameters.
+     *
+     * @param paramMap The data store parameters.
+     * @return An array of supported MIME types.
+     */
     protected String[] getSupportedMimeTypes(final DataStoreParams paramMap) {
         return StreamUtil.split(paramMap.getAsString(SUPPORTED_MIMETYPES, ".*"), ",")
                 .get(stream -> stream.map(String::trim).toArray(n -> new String[n]));
     }
 
+    /**
+     * Stores the shared documents drive.
+     *
+     * @param dataConfig The data configuration.
+     * @param callback The index update callback.
+     * @param configMap The configuration map.
+     * @param paramMap The data store parameters.
+     * @param scriptMap The script map.
+     * @param defaultDataMap The default data map.
+     * @param executorService The executor service.
+     * @param client The Office365Client.
+     * @param driveId The drive ID.
+     */
     protected void storeSharedDocumentsDrive(final DataConfig dataConfig, final IndexUpdateCallback callback,
             final Map<String, Object> configMap, final DataStoreParams paramMap, final Map<String, String> scriptMap,
             final Map<String, Object> defaultDataMap, final ExecutorService executorService, final Office365Client client,
@@ -270,6 +405,18 @@ public class OneDriveDataStore extends Office365DataStore {
                         client, c -> driveId != null ? c.drives(driveId) : c.drive(), item, Collections.emptyList())));
     }
 
+    /**
+     * Stores the users' drives.
+     *
+     * @param dataConfig The data configuration.
+     * @param callback The index update callback.
+     * @param configMap The configuration map.
+     * @param paramMap The data store parameters.
+     * @param scriptMap The script map.
+     * @param defaultDataMap The default data map.
+     * @param executorService The executor service.
+     * @param client The Office365Client.
+     */
     protected void storeUsersDrive(final DataConfig dataConfig, final IndexUpdateCallback callback, final Map<String, Object> configMap,
             final DataStoreParams paramMap, final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap,
             final ExecutorService executorService, final Office365Client client) {
@@ -284,12 +431,29 @@ public class OneDriveDataStore extends Office365DataStore {
         });
     }
 
+    /**
+     * Checks if the current thread is interrupted.
+     *
+     * @param e The exception to check.
+     */
     protected void isInterrupted(final Exception e) {
         if (e instanceof InterruptedException) {
             throw new InterruptedRuntimeException((InterruptedException) e);
         }
     }
 
+    /**
+     * Stores the groups' drives.
+     *
+     * @param dataConfig The data configuration.
+     * @param callback The index update callback.
+     * @param configMap The configuration map.
+     * @param paramMap The data store parameters.
+     * @param scriptMap The script map.
+     * @param defaultDataMap The default data map.
+     * @param executorService The executor service.
+     * @param client The Office365Client.
+     */
     protected void storeGroupsDrive(final DataConfig dataConfig, final IndexUpdateCallback callback, final Map<String, Object> configMap,
             final DataStoreParams paramMap, final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap,
             final ExecutorService executorService, final Office365Client client) {
@@ -300,6 +464,20 @@ public class OneDriveDataStore extends Office365DataStore {
         });
     }
 
+    /**
+     * Processes a drive item.
+     *
+     * @param dataConfig The data configuration.
+     * @param callback The index update callback.
+     * @param configMap The configuration map.
+     * @param paramMap The data store parameters.
+     * @param scriptMap The script map.
+     * @param defaultDataMap The default data map.
+     * @param client The Office365Client.
+     * @param builder The drive request builder.
+     * @param item The drive item.
+     * @param roles The roles.
+     */
     protected void processDriveItem(final DataConfig dataConfig, final IndexUpdateCallback callback, final Map<String, Object> configMap,
             final DataStoreParams paramMap, final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap,
             final Office365Client client, final Function<GraphServiceClient<Request>, DriveRequestBuilder> builder, final DriveItem item,
@@ -473,6 +651,14 @@ public class OneDriveDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Gets the permissions for a drive item.
+     *
+     * @param client The Office365Client.
+     * @param builder The drive request builder.
+     * @param item The drive item.
+     * @return A list of permissions.
+     */
     protected List<String> getDriveItemPermissions(final Office365Client client,
             final Function<GraphServiceClient<Request>, DriveRequestBuilder> builder, final DriveItem item) {
         final List<String> permissions = new ArrayList<>();
@@ -490,6 +676,13 @@ public class OneDriveDataStore extends Office365DataStore {
         return permissions;
     }
 
+    /**
+     * Assigns a permission to a user or group.
+     *
+     * @param client The Office365Client.
+     * @param permissions The list of permissions.
+     * @param permission The permission to assign.
+     */
     protected void assignPermission(final Office365Client client, final List<String> permissions, final Permission permission) {
         final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
         final String id = permission.grantedToV2.user.id;
@@ -544,6 +737,12 @@ public class OneDriveDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Gets the user email from a permission.
+     *
+     * @param permission The permission.
+     * @return The user email.
+     */
     protected String getUserEmail(final Permission permission) {
         if (permission.grantedToV2 != null && permission.grantedToV2.user != null && permission.grantedToV2.user.displayName != null) {
             // TODO email?
@@ -552,6 +751,14 @@ public class OneDriveDataStore extends Office365DataStore {
         return null;
     }
 
+    /**
+     * Gets the URL for a drive item.
+     *
+     * @param configMap The configuration map.
+     * @param paramMap The data store parameters.
+     * @param item The drive item.
+     * @return The URL.
+     */
     protected String getUrl(final Map<String, Object> configMap, final DataStoreParams paramMap, final DriveItem item) {
         if (item.webUrl == null) {
             return null;
@@ -582,6 +789,12 @@ public class OneDriveDataStore extends Office365DataStore {
         return baseUrl + "/Documents/" + path;
     }
 
+    /**
+     * Encodes a URL string.
+     *
+     * @param s The string to encode.
+     * @return The encoded string.
+     */
     protected String encodeUrl(final String s) {
         if (StringUtil.isEmpty(s)) {
             return s;
@@ -594,6 +807,16 @@ public class OneDriveDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Gets the contents of a drive item.
+     *
+     * @param client The Office365Client.
+     * @param builder The drive request builder.
+     * @param item The drive item.
+     * @param maxContentLength The maximum content length.
+     * @param ignoreError true to ignore errors.
+     * @return The contents of the drive item.
+     */
     protected String getDriveItemContents(final Office365Client client,
             final Function<GraphServiceClient<Request>, DriveRequestBuilder> builder, final DriveItem item, final long maxContentLength,
             final boolean ignoreError) {
@@ -616,11 +839,26 @@ public class OneDriveDataStore extends Office365DataStore {
         return StringUtil.EMPTY;
     }
 
+    /**
+     * Gets the drive items in a drive.
+     *
+     * @param client The Office365Client.
+     * @param builder The drive request builder.
+     * @param consumer The consumer to process each drive item.
+     */
     protected void getDriveItemsInDrive(final Office365Client client,
             final Function<GraphServiceClient<Request>, DriveRequestBuilder> builder, final Consumer<DriveItem> consumer) {
         getDriveItemChildren(client, builder, consumer, null);
     }
 
+    /**
+     * Gets the children of a drive item.
+     *
+     * @param client The Office365Client.
+     * @param builder The drive request builder.
+     * @param consumer The consumer to process each drive item.
+     * @param item The drive item.
+     */
     protected void getDriveItemChildren(final Office365Client client,
             final Function<GraphServiceClient<Request>, DriveRequestBuilder> builder, final Consumer<DriveItem> consumer,
             final DriveItem item) {
@@ -658,6 +896,11 @@ public class OneDriveDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Sets the name of the extractor to use for file content.
+     *
+     * @param extractorName The name of the extractor.
+     */
     public void setExtractorName(final String extractorName) {
         this.extractorName = extractorName;
     }

--- a/src/main/java/org/codelibs/fess/ds/office365/OneNoteDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/office365/OneNoteDataStore.java
@@ -51,22 +51,46 @@ import com.microsoft.graph.requests.OnenoteRequestBuilder;
 
 import okhttp3.Request;
 
+/**
+ * This class is a data store for crawling and indexing content from Microsoft OneNote.
+ * It supports crawling notebooks from user accounts, groups, and SharePoint sites.
+ * It extracts notebook content, metadata, and permissions for indexing.
+ */
 public class OneNoteDataStore extends Office365DataStore {
+
+    /**
+     * Default constructor.
+     */
+    public OneNoteDataStore() {
+        super();
+    }
 
     private static final Logger logger = LogManager.getLogger(OneNoteDataStore.class);
 
     // scripts
+    /** Key for the notebook object in the script map. */
     protected static final String NOTEBOOK = "notebook";
+    /** Key for the notebook name in the script map. */
     protected static final String NOTEBOOK_NAME = "name";
+    /** Key for the notebook contents in the script map. */
     protected static final String NOTEBOOK_CONTENTS = "contents";
+    /** Key for the notebook size in the script map. */
     protected static final String NOTEBOOK_SIZE = "size";
+    /** Key for the notebook creation date in the script map. */
     protected static final String NOTEBOOK_CREATED = "created";
+    /** Key for the notebook last modified date in the script map. */
     protected static final String NOTEBOOK_LAST_MODIFIED = "last_modified";
+    /** Key for the notebook web URL in the script map. */
     protected static final String NOTEBOOK_WEB_URL = "web_url";
+    /** Key for the notebook roles in the script map. */
     protected static final String NOTEBOOK_ROLES = "roles";
+    /** Parameter name for the number of threads. */
     protected static final String NUMBER_OF_THREADS = "number_of_threads";
+    /** Parameter name for enabling the site note crawler. */
     protected static final String SITE_NOTE_CRAWLER = "site_note_crawler";
+    /** Parameter name for enabling the user note crawler. */
     protected static final String USER_NOTE_CRAWLER = "user_note_crawler";
+    /** Parameter name for enabling the group note crawler. */
     protected static final String GROUP_NOTE_CRAWLER = "group_note_crawler";
 
     @Override
@@ -110,22 +134,57 @@ public class OneNoteDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Creates a new Office365Client.
+     *
+     * @param params The data store parameters.
+     * @return A new Office365Client.
+     */
     protected Office365Client createClient(final DataStoreParams params) {
         return new Office365Client(params);
     }
 
+    /**
+     * Checks if the group note crawler is enabled.
+     *
+     * @param paramMap The data store parameters.
+     * @return true if the group note crawler is enabled, false otherwise.
+     */
     protected boolean isGroupNoteCrawler(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(GROUP_NOTE_CRAWLER, Constants.TRUE));
     }
 
+    /**
+     * Checks if the user note crawler is enabled.
+     *
+     * @param paramMap The data store parameters.
+     * @return true if the user note crawler is enabled, false otherwise.
+     */
     protected boolean isUserNoteCrawler(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(USER_NOTE_CRAWLER, Constants.TRUE));
     }
 
+    /**
+     * Checks if the site note crawler is enabled.
+     *
+     * @param paramMap The data store parameters.
+     * @return true if the site note crawler is enabled, false otherwise.
+     */
     protected boolean isSiteNoteCrawler(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(SITE_NOTE_CRAWLER, Constants.TRUE));
     }
 
+    /**
+     * Stores the site notes.
+     *
+     * @param dataConfig The data configuration.
+     * @param callback The index update callback.
+     * @param paramMap The data store parameters.
+     * @param scriptMap The script map.
+     * @param defaultDataMap The default data map.
+     * @param executorService The executor service.
+     * @param client The Office365Client.
+     */
     protected void storeSiteNotes(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
             final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final ExecutorService executorService,
             final Office365Client client) {
@@ -135,6 +194,17 @@ public class OneNoteDataStore extends Office365DataStore {
                 callback, paramMap, scriptMap, defaultDataMap, client, c -> c.sites(root.id).onenote(), notebook, roles)));
     }
 
+    /**
+     * Stores the users' notes.
+     *
+     * @param dataConfig The data configuration.
+     * @param callback The index update callback.
+     * @param paramMap The data store parameters.
+     * @param scriptMap The script map.
+     * @param defaultDataMap The default data map.
+     * @param executorService The executor service.
+     * @param client The Office365Client.
+     */
     protected void storeUsersNotes(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
             final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final ExecutorService executorService,
             final Office365Client client) {
@@ -149,6 +219,17 @@ public class OneNoteDataStore extends Office365DataStore {
         });
     }
 
+    /**
+     * Stores the groups' notes.
+     *
+     * @param dataConfig The data configuration.
+     * @param callback The index update callback.
+     * @param paramMap The data store parameters.
+     * @param scriptMap The script map.
+     * @param defaultDataMap The default data map.
+     * @param executorService The executor service.
+     * @param client The Office365Client.
+     */
     protected void storeGroupsNotes(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
             final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final ExecutorService executorService,
             final Office365Client client) {
@@ -159,6 +240,19 @@ public class OneNoteDataStore extends Office365DataStore {
         });
     }
 
+    /**
+     * Processes a notebook.
+     *
+     * @param dataConfig The data configuration.
+     * @param callback The index update callback.
+     * @param paramMap The data store parameters.
+     * @param scriptMap The script map.
+     * @param defaultDataMap The default data map.
+     * @param client The Office365Client.
+     * @param builder The OneNote request builder.
+     * @param notebook The notebook.
+     * @param roles The roles.
+     */
     protected void processNotebook(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
             final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final Office365Client client,
             final Function<GraphServiceClient<Request>, OnenoteRequestBuilder> builder, final Notebook notebook, final List<String> roles) {
@@ -243,6 +337,13 @@ public class OneNoteDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Gets the notebooks.
+     *
+     * @param client The Office365Client.
+     * @param builder The OneNote request builder.
+     * @param consumer The consumer to process each notebook.
+     */
     protected void getNotebooks(final Office365Client client, final Function<GraphServiceClient<Request>, OnenoteRequestBuilder> builder,
             final Consumer<Notebook> consumer) {
         try {

--- a/src/main/java/org/codelibs/fess/ds/office365/TeamsDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/office365/TeamsDataStore.java
@@ -65,53 +65,104 @@ import com.microsoft.graph.models.ConversationMember;
 import com.microsoft.graph.models.Group;
 import com.microsoft.graph.models.ItemBody;
 
+/**
+ * This class is a data store for crawling and indexing content from Microsoft Teams.
+ * It supports crawling messages from teams, channels, and chats.
+ * It extracts message content, metadata, attachments, and permissions for indexing.
+ */
 public class TeamsDataStore extends Office365DataStore {
 
+    /**
+     * Default constructor.
+     */
+    public TeamsDataStore() {
+        super();
+    }
+
+    /** Key for the message title. */
     private static final String MESSAGE_TITLE = "title";
 
+    /** Key for the message content. */
     private static final String MESSAGE_CONTENT = "content";
 
     private static final Logger logger = LogManager.getLogger(TeamsDataStore.class);
 
     // parameters
+    /** Parameter name for the team ID. */
     private static final String TEAM_ID = "team_id";
+    /** Parameter name for the exclude team IDs. */
     private static final String EXCLUDE_TEAM_ID = "exclude_team_ids";
+    /** Parameter name for the include visibility. */
     private static final String INCLUDE_VISIBILITY = "include_visibility";
+    /** Parameter name for the channel ID. */
     private static final String CHANNEL_ID = "channel_id";
+    /** Parameter name for the chat ID. */
     private static final String CHAT_ID = "chat_id";
+    /** Parameter name for the number of threads. */
     protected static final String NUMBER_OF_THREADS = "number_of_threads";
+    /** Parameter name for default permissions. */
     protected static final String DEFAULT_PERMISSIONS = "default_permissions";
+    /** Parameter name for ignoring replies. */
     private static final String IGNORE_REPLIES = "ignore_replies";
+    /** Parameter name for appending attachments. */
     private static final String APPEND_ATTACHMENT = "append_attachment";
+    /** Parameter name for ignoring system events. */
     private static final String IGNORE_SYSTEM_EVENTS = "ignore_system_events";
+    /** Parameter name for the title date format. */
     private static final String TITLE_DATEFORMAT = "title_dateformat";
+    /** Parameter name for the title timezone offset. */
     private static final String TITLE_TIMEZONE = "title_timezone_offset";
 
     // scripts
+    /** Key for the message object in the script map. */
     private static final String MESSAGE = "message";
+    /** Key for the message attachments in the script map (internal use only). */
     private static final String MESSAGE_ATTACHMENTS = "attachments"; // internal user only
+    /** Key for the message body in the script map. */
     private static final String MESSAGE_BODY = "body";
+    /** Key for the message channel identity in the script map. */
     private static final String MESSAGE_CHANNEL_IDENTITY = "channel_identity";
+    /** Key for the message chat ID in the script map. */
     private static final String MESSAGE_CHAT_ID = "chat_id";
+    /** Key for the message created date time in the script map. */
     private static final String MESSAGE_CREATED_DATE_TIME = "created_date_time";
+    /** Key for the message deleted date time in the script map. */
     private static final String MESSAGE_DELETED_DATE_TIME = "deleted_date_time";
+    /** Key for the message eTag in the script map. */
     private static final String MESSAGE_ETAG = "etag";
+    /** Key for the message from in the script map. */
     private static final String MESSAGE_FROM = "from";
+    /** Key for the message hosted contents in the script map (internal use only). */
     private static final String MESSAGE_HOSTED_CONTENTS = "hosted_contents"; // internal user only
+    /** Key for the message ID in the script map. */
     private static final String MESSAGE_ID = "id";
+    /** Key for the message importance in the script map. */
     private static final String MESSAGE_IMPORTANCE = "importance";
+    /** Key for the message last edited date time in the script map. */
     private static final String MESSAGE_LAST_EDITED_DATE_TIME = "last_edited_date_time";
+    /** Key for the message last modified date time in the script map. */
     private static final String MESSAGE_LAST_MODIFIED_DATE_TIME = "last_modified_date_time";
+    /** Key for the message locale in the script map. */
     private static final String MESSAGE_LOCALE = "locale";
+    /** Key for the message mentions in the script map. */
     private static final String MESSAGE_MENTIONS = "mentions";
+    /** Key for the message replies in the script map (internal use only). */
     private static final String MESSAGE_REPLIES = "replies"; // internal user only
+    /** Key for the message reply to ID in the script map. */
     private static final String MESSAGE_REPLY_TO_ID = "reply_to_id";
+    /** Key for the message subject in the script map. */
     private static final String MESSAGE_SUBJECT = "subject";
+    /** Key for the message summary in the script map. */
     private static final String MESSAGE_SUMMARY = "summary";
+    /** Key for the message web URL in the script map. */
     private static final String MESSAGE_WEB_URL = "web_url";
+    /** Key for the message roles in the script map. */
     private static final String MESSAGE_ROLES = "roles";
+    /** Key for the parent object in the script map. */
     private static final String PARENT = "parent";
+    /** Key for the team object in the script map. */
     private static final String TEAM = "team";
+    /** Key for the channel object in the script map. */
     private static final String CHANNEL = "channel";
 
     @Override
@@ -155,6 +206,17 @@ public class TeamsDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Processes chat messages.
+     *
+     * @param dataConfig The data configuration.
+     * @param callback The index update callback.
+     * @param paramMap The data store parameters.
+     * @param scriptMap The script map.
+     * @param defaultDataMap The default data map.
+     * @param configMap The configuration map.
+     * @param client The Office365Client.
+     */
     protected void processChatMessages(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
             final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final Map<String, Object> configMap,
             final Office365Client client) {
@@ -170,6 +232,13 @@ public class TeamsDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Creates a chat message from a list of messages.
+     *
+     * @param msgList The list of chat messages.
+     * @param client The Office365Client.
+     * @return A new chat message.
+     */
     protected ChatMessage createChatMessage(final List<ChatMessage> msgList, final Office365Client client) {
         final ChatMessage msg = new ChatMessage();
         final ChatMessage defaultMsg = msgList.get(0);
@@ -206,6 +275,17 @@ public class TeamsDataStore extends Office365DataStore {
         return msg;
     }
 
+    /**
+     * Processes team messages.
+     *
+     * @param dataConfig The data configuration.
+     * @param callback The index update callback.
+     * @param paramMap The data store parameters.
+     * @param scriptMap The script map.
+     * @param defaultDataMap The default data map.
+     * @param configMap The configuration map.
+     * @param client The Office365Client.
+     */
     protected void processTeamMessages(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
             final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final Map<String, Object> configMap,
             final Office365Client client) {
@@ -311,6 +391,13 @@ public class TeamsDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Gets the set of excluded group IDs based on configured exclude team IDs.
+     *
+     * @param configMap The configuration map containing exclude team ID settings.
+     * @param client The Office365Client for group lookups.
+     * @return A set of group IDs to exclude from processing.
+     */
     protected Set<String> getExcludeGroupIdSet(final Map<String, Object> configMap, final Office365Client client) {
         final String[] teamIds = (String[]) configMap.get(EXCLUDE_TEAM_ID);
         return StreamUtil.stream(teamIds).get(stream -> stream.map(teamId -> {
@@ -325,6 +412,13 @@ public class TeamsDataStore extends Office365DataStore {
         }).collect(Collectors.toSet()));
     }
 
+    /**
+     * Determines if a team visibility level is included in the target visibility settings.
+     *
+     * @param configMap The configuration map containing visibility settings.
+     * @param visibility The visibility level to check.
+     * @return true if the visibility should be processed, false otherwise.
+     */
     protected boolean isTargetVisibility(final Map<String, Object> configMap, final String visibility) {
         final String[] visibilities = (String[]) configMap.get(INCLUDE_VISIBILITY);
         if (visibilities.length == 0) {
@@ -338,30 +432,72 @@ public class TeamsDataStore extends Office365DataStore {
         return false;
     }
 
+    /**
+     * Gets the date formatter for message titles.
+     *
+     * @param paramMap The data store parameters containing date format settings.
+     * @return The configured DateTimeFormatter for titles.
+     */
     protected DateTimeFormatter getTitleDateformat(final DataStoreParams paramMap) {
         return DateTimeFormatter.ofPattern(paramMap.getAsString(TITLE_DATEFORMAT, "yyyy/MM/dd'T'HH:mm:ss"));
     }
 
+    /**
+     * Gets the timezone offset for message titles.
+     *
+     * @param paramMap The data store parameters containing timezone settings.
+     * @return The configured ZoneOffset for titles.
+     */
     protected ZoneOffset getTitleTimezone(final DataStoreParams paramMap) {
         return ZoneOffset.of(paramMap.getAsString(TITLE_TIMEZONE, "Z"));
     }
 
+    /**
+     * Determines if system events should be ignored during processing.
+     *
+     * @param paramMap The data store parameters containing system event settings.
+     * @return true if system events should be ignored, false otherwise.
+     */
     protected Object isIgnoreSystemEvents(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(IGNORE_SYSTEM_EVENTS, Constants.TRUE));
     }
 
+    /**
+     * Determines if attachments should be appended to message content.
+     *
+     * @param paramMap The data store parameters containing attachment settings.
+     * @return true if attachments should be appended, false otherwise.
+     */
     protected Object isAppendAttachment(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(APPEND_ATTACHMENT, Constants.TRUE));
     }
 
+    /**
+     * Determines if reply messages should be ignored during processing.
+     *
+     * @param paramMap The data store parameters containing reply settings.
+     * @return true if replies should be ignored, false otherwise.
+     */
     protected boolean isIgnoreReplies(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(IGNORE_REPLIES, Constants.FALSE));
     }
 
+    /**
+     * Gets the configured team ID for processing a specific team.
+     *
+     * @param paramMap The data store parameters containing team ID setting.
+     * @return The team ID to process, or null if not specified.
+     */
     protected String getTeamId(final DataStoreParams paramMap) {
         return paramMap.getAsString(TEAM_ID);
     }
 
+    /**
+     * Gets the array of team IDs to exclude from processing.
+     *
+     * @param paramMap The data store parameters containing exclude team ID settings.
+     * @return An array of team IDs to exclude.
+     */
     protected String[] getExcludeTeamIds(final DataStoreParams paramMap) {
         final String idStr = paramMap.getAsString(EXCLUDE_TEAM_ID);
         if (StringUtil.isBlank(idStr)) {
@@ -371,6 +507,12 @@ public class TeamsDataStore extends Office365DataStore {
                 .get(stream -> stream.map(s -> s.trim()).filter(StringUtil::isNotBlank).toArray(n -> new String[n]));
     }
 
+    /**
+     * Gets the array of team visibility levels to include in processing.
+     *
+     * @param paramMap The data store parameters containing visibility settings.
+     * @return An array of visibility levels to include.
+     */
     protected String[] getIncludeVisibilities(final DataStoreParams paramMap) {
         final String idStr = paramMap.getAsString(INCLUDE_VISIBILITY);
         if (StringUtil.isBlank(idStr)) {
@@ -380,30 +522,70 @@ public class TeamsDataStore extends Office365DataStore {
                 .get(stream -> stream.map(s -> s.trim()).filter(StringUtil::isNotBlank).toArray(n -> new String[n]));
     }
 
+    /**
+     * Gets the configured channel ID for processing a specific channel.
+     *
+     * @param paramMap The data store parameters containing channel ID setting.
+     * @return The channel ID to process, or null if not specified.
+     */
     protected String getChannelId(final DataStoreParams paramMap) {
         return paramMap.getAsString(CHANNEL_ID);
     }
 
+    /**
+     * Gets the configured chat ID for processing a specific chat.
+     *
+     * @param paramMap The data store parameters containing chat ID setting.
+     * @return The chat ID to process, or null if not specified.
+     */
     protected String getChatId(final DataStoreParams paramMap) {
         return paramMap.getAsString(CHAT_ID);
     }
 
+    /**
+     * Creates a new Office365Client instance for API communication.
+     *
+     * @param params The data store parameters containing authentication settings.
+     * @return A new Office365Client instance.
+     */
     protected Office365Client createClient(final DataStoreParams params) {
         return new Office365Client(params);
     }
 
+    /**
+     * Gets the group roles for members of a specific team channel.
+     *
+     * @param client The Office365Client for API communication.
+     * @param teamId The team ID.
+     * @param channelId The channel ID.
+     * @return A list of group role permissions.
+     */
     protected List<String> getGroupRoles(final Office365Client client, final String teamId, final String channelId) {
         final List<String> permissions = new ArrayList<>();
         client.getChannelMembers(Collections.emptyList(), m -> getGroupRoles(client, permissions, m), teamId, channelId);
         return permissions;
     }
 
+    /**
+     * Gets the group roles for members of a specific chat.
+     *
+     * @param client The Office365Client for API communication.
+     * @param chatId The chat ID.
+     * @return A list of group role permissions.
+     */
     protected List<String> getGroupRoles(final Office365Client client, final String chatId) {
         final List<String> permissions = new ArrayList<>();
         client.getChatMembers(Collections.emptyList(), m -> getGroupRoles(client, permissions, m), chatId);
         return permissions;
     }
 
+    /**
+     * Extracts and adds group roles from a conversation member to the permissions list.
+     *
+     * @param client The Office365Client for API communication.
+     * @param permissions The list to add permissions to.
+     * @param m The conversation member to process.
+     */
     protected void getGroupRoles(final Office365Client client, final List<String> permissions, final ConversationMember m) {
         final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
         if (logger.isDebugEnabled()) {
@@ -465,6 +647,13 @@ public class TeamsDataStore extends Office365DataStore {
         }
     }
 
+    /**
+     * Determines if a chat message is a system event that should be filtered.
+     *
+     * @param configMap The configuration map containing system event settings.
+     * @param message The chat message to check.
+     * @return true if the message is a system event and should be ignored, false otherwise.
+     */
     protected boolean isSystemEvent(final Map<String, Object> configMap, final ChatMessage message) {
         if (((Boolean) configMap.get(IGNORE_SYSTEM_EVENTS)).booleanValue()) {
             if (message.body != null && "<systemEventMessage/>".equals(message.body.content)) {
@@ -476,6 +665,21 @@ public class TeamsDataStore extends Office365DataStore {
         return false;
     }
 
+    /**
+     * Processes a chat message for indexing, extracting content and metadata.
+     *
+     * @param dataConfig The data configuration.
+     * @param callback The index update callback.
+     * @param configMap The configuration map.
+     * @param paramMap The data store parameters.
+     * @param scriptMap The script map for field mappings.
+     * @param defaultDataMap The default data map.
+     * @param permissions The list of permissions for the message.
+     * @param message The chat message to process.
+     * @param resultAppender Consumer to append additional result data.
+     * @param client The Office365Client for API communication.
+     * @return A map containing the processed message data, or null if the message was filtered.
+     */
     protected Map<String, Object> processChatMessage(final DataConfig dataConfig, final IndexUpdateCallback callback,
             final Map<String, Object> configMap, final DataStoreParams paramMap, final Map<String, String> scriptMap,
             final Map<String, Object> defaultDataMap, final List<String> permissions, final ChatMessage message,
@@ -592,6 +796,13 @@ public class TeamsDataStore extends Office365DataStore {
         return messageMap;
     }
 
+    /**
+     * Generates a title for the chat message based on sender and timestamp.
+     *
+     * @param configMap The configuration map containing title formatting settings.
+     * @param message The chat message.
+     * @return The generated title string.
+     */
     protected String getTitle(final Map<String, Object> configMap, final ChatMessage message) {
         final StringBuilder titleBuf = new StringBuilder(100);
         if (message.from != null) {
@@ -617,6 +828,14 @@ public class TeamsDataStore extends Office365DataStore {
         return titleBuf.toString();
     }
 
+    /**
+     * Extracts and formats the content from a chat message, including attachments if configured.
+     *
+     * @param configMap The configuration map containing content extraction settings.
+     * @param message The chat message.
+     * @param client The Office365Client for API communication.
+     * @return The formatted message content.
+     */
     protected String getConent(final Map<String, Object> configMap, final ChatMessage message, final Office365Client client) {
         final StringBuilder bodyBuf = new StringBuilder(1000);
         if (message.body != null) {
@@ -647,6 +866,12 @@ public class TeamsDataStore extends Office365DataStore {
         return bodyBuf.toString();
     }
 
+    /**
+     * Normalizes text content by removing attachment tags and extra whitespace.
+     *
+     * @param content The raw text content.
+     * @return The normalized text content.
+     */
     protected String normalizeTextContent(final String content) {
         if (StringUtil.isBlank(content)) {
             return StringUtil.EMPTY;
@@ -654,6 +879,12 @@ public class TeamsDataStore extends Office365DataStore {
         return content.replaceAll("<attachment[^>]*></attachment>", StringUtil.EMPTY).trim();
     }
 
+    /**
+     * Strips HTML tags from the given value using Lucene's HTML strip filter.
+     *
+     * @param value The HTML content to strip tags from.
+     * @return The text content with HTML tags removed.
+     */
     protected String stripHtmlTags(final String value) {
         if (value == null) {
             return "";

--- a/src/main/java/org/codelibs/fess/ds/office365/TeamsDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/office365/TeamsDataStore.java
@@ -249,7 +249,7 @@ public class TeamsDataStore extends Office365DataStore {
         final StringBuilder bodyBuf = new StringBuilder(1000);
         final Map<String, Object> configMap = new HashMap<>();
         configMap.put(APPEND_ATTACHMENT, false);
-        msgList.stream().forEach(m -> bodyBuf.append(getConent(configMap, m, client)));
+        msgList.stream().forEach(m -> bodyBuf.append(getContent(configMap, m, client)));
         msg.body.content = bodyBuf.toString();
         msg.channelIdentity = defaultMsg.channelIdentity;
         msg.createdDateTime = defaultMsg.createdDateTime;
@@ -704,7 +704,7 @@ public class TeamsDataStore extends Office365DataStore {
         try {
             crawlerStatsHelper.begin(statsKey);
 
-            messageMap.put(MESSAGE_CONTENT, getConent(configMap, message, client));
+            messageMap.put(MESSAGE_CONTENT, getContent(configMap, message, client));
             messageMap.put(MESSAGE_TITLE, getTitle(configMap, message));
 
             messageMap.put(MESSAGE_ATTACHMENTS, message.attachments);
@@ -836,7 +836,7 @@ public class TeamsDataStore extends Office365DataStore {
      * @param client The Office365Client for API communication.
      * @return The formatted message content.
      */
-    protected String getConent(final Map<String, Object> configMap, final ChatMessage message, final Office365Client client) {
+    protected String getContent(final Map<String, Object> configMap, final ChatMessage message, final Office365Client client) {
         final StringBuilder bodyBuf = new StringBuilder(1000);
         if (message.body != null) {
             switch (message.body.contentType) {

--- a/src/main/java/org/codelibs/fess/ds/office365/client/Office365Client.java
+++ b/src/main/java/org/codelibs/fess/ds/office365/client/Office365Client.java
@@ -237,7 +237,6 @@ public class Office365Client implements Closeable {
      * @param id The ID of the user or group.
      * @return The UserType of the specified ID.
      */
-
     public UserType getUserType(final String id) {
         if (StringUtil.isBlank(id)) {
             return UserType.UNKNOWN;

--- a/src/main/java/org/codelibs/fess/ds/office365/client/Office365Client.java
+++ b/src/main/java/org/codelibs/fess/ds/office365/client/Office365Client.java
@@ -82,28 +82,52 @@ import com.microsoft.graph.serializer.AdditionalDataManager;
 
 import okhttp3.Request;
 
+/**
+ * This class provides a client for accessing Microsoft Office 365 services using the Microsoft Graph API.
+ * It handles authentication, and provides methods for interacting with services like OneDrive, OneNote, and Teams.
+ * This client is designed to be used within the Fess data store framework.
+ */
 public class Office365Client implements Closeable {
 
     private static final Logger logger = LogManager.getLogger(Office365Client.class);
 
+    /** The parameter name for the Azure AD tenant ID. */
     protected static final String TENANT_PARAM = "tenant";
+    /** The parameter name for the Azure AD client ID. */
     protected static final String CLIENT_ID_PARAM = "client_id";
+    /** The parameter name for the Azure AD client secret. */
     protected static final String CLIENT_SECRET_PARAM = "client_secret";
+    /** The parameter name for the access timeout. */
     protected static final String ACCESS_TIMEOUT = "access_timeout";
+    /** The parameter name for the refresh token interval. */
     protected static final String REFRESH_TOKEN_INTERVAL = "refresh_token_interval";
+    /** The parameter name for the user type cache size. */
     protected static final String USER_TYPE_CACHE_SIZE = "user_type_cache_size";
+    /** The parameter name for the group ID cache size. */
     protected static final String GROUP_ID_CACHE_SIZE = "group_id_cache_size";
+    /** The parameter name for the maximum content length. */
     protected static final String MAX_CONTENT_LENGTH = "max_content_length";
 
+    /** Error code for an invalid authentication token. */
     protected static final String INVALID_AUTHENTICATION_TOKEN = "InvalidAuthenticationToken";
 
+    /** The Microsoft Graph service client. */
     protected GraphServiceClient<Request> client;
+    /** The data store parameters. */
     protected DataStoreParams params;
+    /** A cache for user types. */
     protected LoadingCache<String, UserType> userTypeCache;
+    /** A cache for group IDs. */
     protected LoadingCache<String, String[]> groupIdCache;
 
+    /** The maximum content length for extracted text. */
     protected int maxContentLength = -1;
 
+    /**
+     * Constructs a new Office365Client with the specified data store parameters.
+     *
+     * @param params The data store parameters for configuration.
+     */
     public Office365Client(final DataStoreParams params) {
         this.params = params;
 
@@ -195,9 +219,24 @@ public class Office365Client implements Closeable {
         groupIdCache.invalidateAll();
     }
 
+    /**
+     * An enumeration of user types in Office 365.
+     */
     public enum UserType {
-        USER, GROUP, UNKNOWN;
+        /** Represents a regular user. */
+        USER,
+        /** Represents a group. */
+        GROUP,
+        /** Represents an unknown user type. */
+        UNKNOWN;
     }
+
+    /**
+     * Retrieves the type of a user (user, group, or unknown) by their ID.
+     *
+     * @param id The ID of the user or group.
+     * @return The UserType of the specified ID.
+     */
 
     public UserType getUserType(final String id) {
         if (StringUtil.isBlank(id)) {
@@ -211,15 +250,36 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves the content of a drive item as an InputStream.
+     *
+     * @param builder A function that builds a DriveRequestBuilder.
+     * @param id The ID of the drive item.
+     * @return An InputStream containing the content of the drive item.
+     */
     public InputStream getDriveContent(final Function<GraphServiceClient<Request>, DriveRequestBuilder> builder, final String id) {
         return builder.apply(client).items(id).content().buildRequest().get();
     }
 
+    /**
+     * Retrieves the permissions for a drive item.
+     *
+     * @param builder A function that builds a DriveRequestBuilder.
+     * @param id The ID of the drive item.
+     * @return A PermissionCollectionPage containing the permissions.
+     */
     public PermissionCollectionPage getDrivePermissions(final Function<GraphServiceClient<Request>, DriveRequestBuilder> builder,
             final String id) {
         return builder.apply(client).items(id).permissions().buildRequest().get();
     }
 
+    /**
+     * Retrieves a page of drive items within a drive.
+     *
+     * @param builder A function that builds a DriveRequestBuilder.
+     * @param id The ID of the parent drive item, or null for the root.
+     * @return A DriveItemCollectionPage containing the drive items.
+     */
     public DriveItemCollectionPage getDriveItemPage(final Function<GraphServiceClient<Request>, DriveRequestBuilder> builder,
             final String id) {
         if (id == null) {
@@ -228,10 +288,23 @@ public class Office365Client implements Closeable {
         return builder.apply(client).items(id).children().buildRequest().get();
     }
 
+    /**
+     * Retrieves a user by their ID.
+     *
+     * @param userId The ID of the user.
+     * @param options A list of options for the request.
+     * @return The User object.
+     */
     public User getUser(final String userId, final List<? extends Option> options) {
         return client.users(userId).buildRequest(options).get();
     }
 
+    /**
+     * Retrieves a list of users, processing each user with the provided consumer.
+     *
+     * @param options A list of query options for the request.
+     * @param consumer A consumer to process each User object.
+     */
     public void getUsers(final List<QueryOption> options, final Consumer<User> consumer) {
         UserCollectionPage page = client.users().buildRequest(options).get();
         page.getCurrentPage().forEach(consumer::accept);
@@ -241,6 +314,12 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves the group IDs associated with an email address.
+     *
+     * @param email The email address to search for.
+     * @return An array of group IDs.
+     */
     public String[] getGroupIdsByEmail(final String email) {
         try {
             return groupIdCache.get(email);
@@ -250,6 +329,12 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves a list of groups, processing each group with the provided consumer.
+     *
+     * @param options A list of query options for the request.
+     * @param consumer A consumer to process each Group object.
+     */
     public void getGroups(final List<QueryOption> options, final Consumer<Group> consumer) {
         GroupCollectionPage page = client.groups().buildRequest(options).get();
         page.getCurrentPage().forEach(consumer::accept);
@@ -259,6 +344,12 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves a group by its ID.
+     *
+     * @param id The ID of the group.
+     * @return The Group object, or null if not found.
+     */
     public Group getGroupById(final String id) {
         final List<Group> groupList = new ArrayList<>();
         getGroups(Collections.singletonList(new QueryOption("$filter", "id eq '" + id + "'")), g -> groupList.add(g));
@@ -271,10 +362,22 @@ public class Office365Client implements Closeable {
         return null;
     }
 
+    /**
+     * Retrieves a page of notebooks.
+     *
+     * @param builder A function that builds an OnenoteRequestBuilder.
+     * @return a NotebookCollectionPage containing the notebooks.
+     */
     public NotebookCollectionPage getNotebookPage(final Function<GraphServiceClient<Request>, OnenoteRequestBuilder> builder) {
         return builder.apply(client).notebooks().buildRequest().get();
     }
 
+    /**
+     * Retrieves all sections within a notebook.
+     *
+     * @param builder The NotebookRequestBuilder for the notebook.
+     * @return A list of OnenoteSection objects.
+     */
     protected List<OnenoteSection> getSections(final NotebookRequestBuilder builder) {
         OnenoteSectionCollectionPage page = builder.sections().buildRequest().get();
         final List<OnenoteSection> sections = new ArrayList<>(page.getCurrentPage());
@@ -285,6 +388,12 @@ public class Office365Client implements Closeable {
         return sections;
     }
 
+    /**
+     * Retrieves all pages within a section.
+     *
+     * @param builder The OnenoteSectionRequestBuilder for the section.
+     * @return A list of OnenotePage objects.
+     */
     protected List<OnenotePage> getPages(final OnenoteSectionRequestBuilder builder) {
         OnenotePageCollectionPage page = builder.pages().buildRequest().get();
         final List<OnenotePage> pages = new ArrayList<>(page.getCurrentPage());
@@ -295,6 +404,13 @@ public class Office365Client implements Closeable {
         return pages;
     }
 
+    /**
+     * Retrieves the contents of a OneNote section as a single string.
+     *
+     * @param builder The OnenoteRequestBuilder for the OneNote.
+     * @param section The OnenoteSection to retrieve contents from.
+     * @return A string containing the concatenated contents of the section.
+     */
     protected String getSectionContents(final OnenoteRequestBuilder builder, final OnenoteSection section) {
         final StringBuilder sb = new StringBuilder();
         sb.append(section.displayName).append('\n');
@@ -304,6 +420,13 @@ public class Office365Client implements Closeable {
         return sb.toString();
     }
 
+    /**
+     * Retrieves the contents of a OneNote page as a single string.
+     *
+     * @param builder The OnenoteRequestBuilder for the OneNote.
+     * @param page The OnenotePage to retrieve contents from.
+     * @return A string containing the contents of the page.
+     */
     protected String getPageContents(final OnenoteRequestBuilder builder, final OnenotePage page) {
         final StringBuilder sb = new StringBuilder();
         sb.append(page.title).append('\n');
@@ -323,12 +446,25 @@ public class Office365Client implements Closeable {
         return sb.toString();
     }
 
+    /**
+     * Retrieves the content of a notebook as a single string.
+     *
+     * @param builder A function that builds an OnenoteRequestBuilder.
+     * @param id The ID of the notebook.
+     * @return A string containing the concatenated contents of the notebook.
+     */
     public String getNotebookContent(final Function<GraphServiceClient<Request>, OnenoteRequestBuilder> builder, final String id) {
         final List<OnenoteSection> sections = getSections(builder.apply(client).notebooks(id));
         Collections.reverse(sections);
         return sections.stream().map(section -> getSectionContents(builder.apply(client), section)).collect(Collectors.joining("\n"));
     }
 
+    /**
+     * Retrieves a site by its ID.
+     *
+     * @param id The ID of the site, or "root" for the root site.
+     * @return The Site object.
+     */
     public Site getSite(final String id) {
         return client.sites(StringUtil.isNotBlank(id) ? id : "root").buildRequest().get();
     }
@@ -344,10 +480,21 @@ public class Office365Client implements Closeable {
     //        return page.getNextPage().buildRequest().get();
     //    }
 
+    /**
+     * Retrieves a drive by its ID.
+     *
+     * @param driveId The ID of the drive.
+     * @return The Drive object.
+     */
     public Drive getDrive(final String driveId) {
         return client.drives(driveId).buildRequest().get();
     }
 
+    /**
+     * Retrieves all drives, processing each drive with the provided consumer.
+     *
+     * @param consumer A consumer to process each Drive object.
+     */
     // for testing
     protected void getDrives(final Consumer<Drive> consumer) {
         DriveCollectionPage page = client.drives().buildRequest().get();
@@ -358,6 +505,12 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves a list of Teams, processing each Team with the provided consumer.
+     *
+     * @param options A list of query options for the request.
+     * @param consumer A consumer to process each Group object representing a Team.
+     */
     public void geTeams(final List<QueryOption> options, final Consumer<Group> consumer) {
         GroupCollectionPage page = client.groups().buildRequest(options).get();
         final Consumer<Group> filter = g -> {
@@ -380,6 +533,13 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves a list of channels in a Team, processing each channel with the provided consumer.
+     *
+     * @param options A list of query options for the request.
+     * @param consumer A consumer to process each Channel object.
+     * @param teamId The ID of the Team.
+     */
     public void getChannels(final List<QueryOption> options, final Consumer<Channel> consumer, final String teamId) {
         ChannelCollectionPage page = client.teams(teamId).channels().buildRequest(options).get();
         page.getCurrentPage().forEach(consumer::accept);
@@ -389,6 +549,13 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves a channel by its ID.
+     *
+     * @param teamId The ID of the Team.
+     * @param id The ID of the channel.
+     * @return The Channel object, or null if not found.
+     */
     public Channel getChannelById(final String teamId, final String id) {
         final List<Channel> channelList = new ArrayList<>();
         getChannels(Collections.singletonList(new QueryOption("$filter", "id eq '" + id + "'")), g -> channelList.add(g), teamId);
@@ -401,6 +568,14 @@ public class Office365Client implements Closeable {
         return null;
     }
 
+    /**
+     * Retrieves a list of messages from a Team channel, processing each message with the provided consumer.
+     *
+     * @param options A list of query options for the request.
+     * @param consumer A consumer to process each ChatMessage object.
+     * @param teamId The ID of the Team.
+     * @param channelId The ID of the channel.
+     */
     public void getTeamMessages(final List<QueryOption> options, final Consumer<ChatMessage> consumer, final String teamId,
             final String channelId) {
         ChatMessageCollectionPage page = client.teams(teamId).channels(channelId).messages().buildRequest(options).get();
@@ -411,6 +586,16 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves a list of reply messages to a specific message in a Team channel,
+     * processing each message with the provided consumer.
+     *
+     * @param options A list of query options for the request.
+     * @param consumer A consumer to process each ChatMessage object.
+     * @param teamId The ID of the Team.
+     * @param channelId The ID of the channel.
+     * @param messageId The ID of the message to retrieve replies for.
+     */
     public void getTeamReplyMessages(final List<QueryOption> options, final Consumer<ChatMessage> consumer, final String teamId,
             final String channelId, final String messageId) {
         ChatMessageCollectionPage page = client.teams(teamId).channels(channelId).messages(messageId).replies().buildRequest(options).get();
@@ -421,6 +606,14 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves a list of members in a channel, processing each member with the provided consumer.
+     *
+     * @param options A list of query options for the request.
+     * @param consumer A consumer to process each ConversationMember object.
+     * @param teamId The ID of the Team.
+     * @param channelId The ID of the channel.
+     */
     public void getChannelMembers(final List<QueryOption> options, final Consumer<ConversationMember> consumer, final String teamId,
             final String channelId) {
         ConversationMemberCollectionPage page = client.teams(teamId).channels(channelId).members().buildRequest(options).get();
@@ -431,6 +624,12 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves a list of chats, processing each chat with the provided consumer.
+     *
+     * @param options A list of query options for the request.
+     * @param consumer A consumer to process each Chat object.
+     */
     public void getChats(final List<QueryOption> options, final Consumer<Chat> consumer) {
         ChatCollectionPage page = client.chats().buildRequest(options).get();
         page.getCurrentPage().forEach(consumer::accept);
@@ -440,6 +639,13 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves a list of messages from a chat, processing each message with the provided consumer.
+     *
+     * @param options A list of query options for the request.
+     * @param consumer A consumer to process each ChatMessage object.
+     * @param chatId The ID of the chat.
+     */
     public void getChatMessages(final List<QueryOption> options, final Consumer<ChatMessage> consumer, final String chatId) {
         ChatMessageCollectionPage page = client.chats(chatId).messages().buildRequest(options).get();
         page.getCurrentPage().forEach(consumer::accept);
@@ -449,6 +655,15 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves a list of reply messages to a specific message in a chat,
+     * processing each message with the provided consumer.
+     *
+     * @param options A list of query options for the request.
+     * @param consumer A consumer to process each ChatMessage object.
+     * @param chatId The ID of the chat.
+     * @param messageId The ID of the message to retrieve replies for.
+     */
     public void getChatReplyMessages(final List<QueryOption> options, final Consumer<ChatMessage> consumer, final String chatId,
             final String messageId) {
         ChatMessageCollectionPage page = client.chats(chatId).messages(messageId).replies().buildRequest(options).get();
@@ -459,6 +674,12 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves a chat by its ID.
+     *
+     * @param id The ID of the chat.
+     * @return The Chat object, or null if not found.
+     */
     public Chat getChatById(final String id) {
         final List<Chat> chatList = new ArrayList<>();
         getChats(Collections.singletonList(new QueryOption("$filter", "id eq '" + id + "'")), g -> chatList.add(g));
@@ -471,6 +692,13 @@ public class Office365Client implements Closeable {
         return null;
     }
 
+    /**
+     * Retrieves a list of members in a chat, processing each member with the provided consumer.
+     *
+     * @param options A list of query options for the request.
+     * @param consumer A consumer to process each ConversationMember object.
+     * @param chatId The ID of the chat.
+     */
     public void getChatMembers(final List<QueryOption> options, final Consumer<ConversationMember> consumer, final String chatId) {
         ConversationMemberCollectionPage page = client.chats(chatId).members().buildRequest(options).get();
         page.getCurrentPage().forEach(consumer::accept);
@@ -480,6 +708,12 @@ public class Office365Client implements Closeable {
         }
     }
 
+    /**
+     * Retrieves the content of a chat message attachment as a string.
+     *
+     * @param attachment The ChatMessageAttachment to retrieve content from.
+     * @return A string containing the content of the attachment.
+     */
     public String getAttachmentContent(final ChatMessageAttachment attachment) {
         if (attachment.content != null || StringUtil.isBlank(attachment.contentUrl)) {
             return StringUtil.EMPTY;


### PR DESCRIPTION
This PR adds comprehensive Javadoc comments to the Office365DataStore and its subclasses (OneDriveDataStore, OneNoteDataStore, and TeamsDataStore), as well as the Office365Client. The documentation clarifies class responsibilities, method functionalities, parameters, return values, and internal constants. These improvements aim to enhance code readability, maintainability, and developer onboarding.
